### PR TITLE
Implement optional reading of configfile from argument or stdin (closes #8)

### DIFF
--- a/kobopatch/kobopatch.go
+++ b/kobopatch/kobopatch.go
@@ -48,17 +48,15 @@ func main() {
 
 	var cfgbuf []byte
 	var err error
-	args := os.Args[1:]
-	fmt.Printf("length of args = %d\n", len(args))
-	if len(args) > 0 {
-		cfgfile := args[0]
+	if len(os.Args) > 1 {
+		cfgfile := os.Args[1]
 		if cfgfile == "-" {
 			fmt.Printf("Reading config file from stdin\n")
 			cfgbuf, err = ioutil.ReadAll(os.Stdin)
 			checkErr(err, "Could not read kobopatch.yaml from stdin")
 		} else {
-			fmt.Printf("Reading config file from %s\n", args[0])
-			cfgbuf, err = ioutil.ReadFile(args[0])
+			fmt.Printf("Reading config file from %s\n", cfgfile)
+			cfgbuf, err = ioutil.ReadFile(cfgfile)
 			checkErr(err, "Could not read kobopatch.yaml from argument")
 		}
 	} else {

--- a/kobopatch/kobopatch.go
+++ b/kobopatch/kobopatch.go
@@ -46,10 +46,27 @@ func main() {
 	fmt.Printf("kobopatch %s\n", version)
 	fmt.Printf("https://github.com/geek1011/kobopatch\n\n")
 
-	fmt.Printf("Reading config file (kobopatch.yaml)\n")
+	var cfgbuf []byte
+	var err error
+	args := os.Args[1:]
+	fmt.Printf("length of args = %d\n", len(args))
+	if len(args) > 0 {
+		cfgfile := args[0]
+		if cfgfile == "-" {
+			fmt.Printf("Reading config file from stdin\n")
+			cfgbuf, err = ioutil.ReadAll(os.Stdin)
+			checkErr(err, "Could not read kobopatch.yaml from stdin")
+		} else {
+			fmt.Printf("Reading config file from %s\n", args[0])
+			cfgbuf, err = ioutil.ReadFile(args[0])
+			checkErr(err, "Could not read kobopatch.yaml from argument")
+		}
+	} else {
+		fmt.Printf("Reading config file (kobopatch.yaml)\n")
+		cfgbuf, err = ioutil.ReadFile("./kobopatch.yaml")
+		checkErr(err, "Could not read kobopatch.yaml")
+	}
 
-	cfgbuf, err := ioutil.ReadFile("./kobopatch.yaml")
-	checkErr(err, "Could not read kobopatch.yaml")
 
 	cfg := &config{}
 	err = yaml.UnmarshalStrict(cfgbuf, &cfg)

--- a/kobopatch/kobopatch.go
+++ b/kobopatch/kobopatch.go
@@ -46,6 +46,8 @@ func main() {
 	fmt.Printf("kobopatch %s\n", version)
 	fmt.Printf("https://github.com/geek1011/kobopatch\n\n")
 
+	outBase := ""
+
 	var cfgbuf []byte
 	var err error
 	if len(os.Args) > 1 {
@@ -58,6 +60,9 @@ func main() {
 			fmt.Printf("Reading config file from %s\n", cfgfile)
 			cfgbuf, err = ioutil.ReadFile(cfgfile)
 			checkErr(err, "Could not read kobopatch.yaml from argument")
+			outBase = filepath.Dir(cfgfile)
+			os.Chdir(outBase)
+			outBase += "/"
 		}
 	} else {
 		fmt.Printf("Reading config file (kobopatch.yaml)\n")
@@ -407,7 +412,7 @@ func main() {
 	}
 
 	log("patch success\n")
-	fmt.Printf("Successfully saved patched KoboRoot.tgz to %s. Remember to make sure your kobo is running the target firmware version before patching.\n", cfg.Out)
+	fmt.Printf("Successfully saved patched KoboRoot.tgz to %s%s. Remember to make sure your kobo is running the target firmware version before patching.\n", outBase, cfg.Out)
 
 	if runtime.GOOS == "windows" {
 		fmt.Printf("\n\nWaiting 60 seconds because runnning on Windows\n")


### PR DESCRIPTION
If the no argument is given, read kobopatch.yaml from cwd, as it is by now
If the first argument is "-" (without the "), read from stdin
If the first argument is anything else, assume it is a file and try to read the yaml from it

closes #8 