### PR TITLE
Implement symlinks declaration in yaml manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ An improved patching system for Kobo eReaders. See https://www.mobileread.com/fo
 ## Features
 - Zlib replacement.
 - Add additional files.
+- Add additional symlinks.
 - Translation file support.
 - Simplified BLX instruction replacement.
 - Multi-version configuration file.


### PR DESCRIPTION
This feature can include symlinks in the generated archive. This is useful to reference binaries installed in `/mnt/onboard` when they are too big to be supported by the root filesystem (for example tailscale).